### PR TITLE
Use Procursus action over manual setup in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,5 +51,5 @@ jobs:
       - name: Upload Permasign deb
         uses: actions/upload-artifact@v3.1.0
         with:
-          name: SantanderPermasigned
+          name: SantanderJailbroken
           path: ${{ github.workspace }}/Santander.deb

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,5 +51,5 @@ jobs:
       - name: Upload Permasign deb
         uses: actions/upload-artifact@v3.1.0
         with:
-          name: Santander-Permasign
+          name: SantanderPermasigned
           path: ${{ github.workspace }}/Santander.deb

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,80 +1,55 @@
+name: CI
+
 on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
+      - '.gitignore'
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - '**/*.md'
+      - '.gitignore'
   workflow_dispatch:
   
-name: Build
 jobs:
   build:
-    name: Build and Upload
+    name: Build
     runs-on: macos-12
-    
+
     steps:
-      - uses: actions/cache@v2
-        id: procache
-        with:
-          path: |
-            ~/__cache
-          key: ${{ runner.os }}-procursus
-          
       - name: Checkout
-        uses: actions/checkout@master
-        
-      - name: Setup Procursus Bootstrap (install)
-        if: steps.procache.outputs.cache-hit != 'true'
-        run: |
-          wget https://apt.procurs.us/bootstrap_darwin-amd64.tar.zst
-          sudo gtar --preserve-permissions -xkf ./bootstrap_darwin-amd64.tar.zst -C /
-          echo '/opt/procursus/sbin:/opt/procursus/bin' >> $GITHUB_PATH
-          PATH=/opt/procursus/sbin:/opt/procursus/bin:$PATH sudo /opt/procursus/bin/apt update
-          sudo /opt/procursus/bin/apt -V dist-upgrade -y || :
-          sudo /opt/procursus/bin/apt -V dist-upgrade -y
-          sudo /opt/procursus/bin/apt install ldid -y
-          
-      - name: Add Procursus to PATH
-        run: |
-          echo '/opt/procursus/sbin:/opt/procursus/bin' >> $GITHUB_PATH
-          
-      - name: Setup Procursus Bootstrap (cache)
-        if: steps.procache.outputs.cache-hit == 'true'
-        run: |
-          sudo mkdir -p ~/__cache/procursus/var/cache/apt/archives/partial ~/__cache/procursus/var/lib/apt/lists/partial
-          sudo rsync -aP ~/__cache/procursus /opt
-          sudo /opt/procursus/bin/apt update
-          sudo /opt/procursus/bin/apt -V dist-upgrade -y
-          sudo /opt/procursus/bin/apt -V dist-upgrade -y
-      
-      - name: Select Correct Xcode (14.0)
+        uses: actions/checkout@v2
+      - name: Set up Procursus
+        uses: beerpiss/procursus-action@v1
+        with:
+          packages: ldid
+          cache: true
+          cache-path: ~/__cache
+          mirror: 'https://repo.quiprr.dev/procursus/'
+      - name: Select Xcode version (14.0)
         run: |
           sudo xcode-select --switch /Applications/Xcode_14.0.app
-          
-      - name: Build and Package IPA
+      - name: Build IPA
         run: |
           xcodebuild build -scheme Santander -configuration "Release" CODE_SIGNING_ALLOWED="NO" CODE_SIGNING_REQUIRED="NO" CODE_SIGN_IDENTITY="" BUILD_DIR=${{ github.workspace }}/xcodebuild
-          
           mkdir -p ${{ github.workspace }}/ipadir/Payload
           cp -R ${{ github.workspace }}/xcodebuild/Release-iphoneos/Santander.app ${{ github.workspace }}/ipadir/Payload
           cd ${{ github.workspace }}/ipadir
           zip -r ${{ github.workspace }}/Santander.ipa .
 
-          pip3 install permasigner
+          pip3 install -U git+https://github.com/itsnebulalol/permasigner.git
           permasigner -d -p ${{ github.workspace }}/Santander.ipa -o ${{ github.workspace }}/Santander.deb -e ${{ github.workspace }}/entitlements.plist
-          
       - name: Upload IPA
         uses: actions/upload-artifact@v3.1.0
         with:
-          name: Santander.ipa
+          name: Santander
           path: ${{ github.workspace }}/Santander.ipa
-
-      - name: Upload deb
+      - name: Upload Permasign deb
         uses: actions/upload-artifact@v3.1.0
         with:
-          name: Santander.deb
+          name: Santander-Permasign
           path: ${{ github.workspace }}/Santander.deb
-          
-      - name: Copy Procursus to Cache Location
-        run: |
-          sudo mkdir -p ~/__cache
-          sudo rsync -aP /opt/procursus ~/__cache
-          sudo rm -rf ~/__cache/procursus/var/cache/apt/archives/partial ~/__cache/procursus/var/lib/apt/lists/partial ~/__cache/procursus/Library/dpkg/triggers/Lock


### PR DESCRIPTION
This PR contains the following changes

* Allow CI to run on code changes, only
* Allow CI to run on PRs made to main branch
* Use Procursus action over manual setup in CI
* Remove unnecessary file extensions on uploaded artifacts