### PR TITLE
Use permasigner/action over manual installation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,8 +43,8 @@ jobs:
       - name: Permasign built IPA
         uses: permasigner/action@v1.1.0
         with:
-          input: "${{ github.worksapce }}/Santander.ipa"
-          output: "${{ github.worksapce }}/Santander.deb"
+          input: "${{ github.workspace }}/Santander.ipa"
+          output: "${{ github.workspace }}/Santander.deb"
           entitlements: "${{ github.workspace }}/entitlements.plist"
       - name: Upload IPA
         uses: actions/upload-artifact@v3.1.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,9 +40,12 @@ jobs:
           cp -R ${{ github.workspace }}/xcodebuild/Release-iphoneos/Santander.app ${{ github.workspace }}/ipadir/Payload
           cd ${{ github.workspace }}/ipadir
           zip -r ${{ github.workspace }}/Santander.ipa .
-
-          pip3 install -U git+https://github.com/itsnebulalol/permasigner.git
-          permasigner -d -p ${{ github.workspace }}/Santander.ipa -o ${{ github.workspace }}/Santander.deb -e ${{ github.workspace }}/entitlements.plist
+      - name: Permasign built IPA
+        uses: permasign/action@v1.1.0
+        with:
+          input: "${{ github.worksapce }}/Santander.ipa"
+          output: "${{ github.worksapce }}/Santander.deb"
+          entitlements: "${{ github.workspace }}/entitlements.plist"
       - name: Upload IPA
         uses: actions/upload-artifact@v3.1.0
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
           cd ${{ github.workspace }}/ipadir
           zip -r ${{ github.workspace }}/Santander.ipa .
       - name: Permasign built IPA
-        uses: permasign/action@v1.1.0
+        uses: permasigner/action@v1.1.0
         with:
           input: "${{ github.worksapce }}/Santander.ipa"
           output: "${{ github.worksapce }}/Santander.deb"


### PR DESCRIPTION
This small PR ensures that CI uses the newly made Github action for `permasigner`, which can be found [here](https://github.com/permasigner/action).