### PR TITLE
Fix any errors in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v3
         
       - name: Set up Procursus
-        uses: beerpiss/procursus-action@v1
+        uses: beerpiss/procursus-action@v2
         with:
           packages: ldid
           cache: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ on:
       - '**/*.md'
       - '.gitignore'
   workflow_dispatch:
-  
+
 jobs:
   build:
     name: Build
@@ -24,22 +24,22 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        
+
       - name: Set up Procursus
         uses: beerpiss/procursus-action@v2
         with:
           packages: ldid
           cache: true
           cache-path: ~/__cache
-          
+
       - name: Select Xcode version (14.0)
         run: |
           sudo xcode-select --switch /Applications/Xcode_14.0.app
-          
+
       - name: Build IPA
         run: |
           make
-            
+
       - name: Permasign IPA
         uses: permasigner/action@v1.1.0
         with:
@@ -47,19 +47,19 @@ jobs:
           output: "${{ github.workspace }}/build/Santander.deb"
           entitlements: "${{ github.workspace }}/entitlements-TS.plist"
           args: "--author Serena"
-          
+
       - name: Upload IPA
         uses: actions/upload-artifact@v3.1.0
         with:
           name: SantanderJailed
           path: ${{ github.workspace }}/build/SantanderJailed.ipa
-          
+
       - name: Upload IPA for TrollStore
         uses: actions/upload-artifact@v3.1.0
         with:
           name: SantanderTrollStore
           path: ${{ github.workspace }}/build/SantanderTrollStore.tipa
-          
+
       - name: Upload Permasigned deb
         uses: actions/upload-artifact@v3.1.0
         with:


### PR DESCRIPTION
The following pull request introduces these fixes

- Fix any warnings regarding NodeJS 12. All workflow actions used have migrated to that breaking change
- Fix any warnings regarding a breaking change in Github Workflows. All workflow actions used have migrated to that change
- Upgrade beerpiss/procursus-action to v2 to use the newly created Procursus bootstraps and deal with breaking changes
- Clean up the workflow file from trail whitespace. My editor does this, yours should too.. or something